### PR TITLE
Ccp 11105 ssm bug fixes

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -18,8 +18,12 @@ output "iam_role_arn" {
   value = aws_iam_role.ssm_role.arn
 }
 
-output "iam_policy_arn" {
+output "iam_cwl_access_policy_arn" {
   value = aws_iam_policy.ssm_s3_cwl_access.arn
+}
+
+output "iam_environment_specific_policy_arn" {
+  value = aws_iam_policy.ssm_environment_specific_access.arn
 }
 
 output "iam_profile_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "iam_cwl_access_policy_arn" {
 }
 
 output "iam_environment_specific_policy_arn" {
-  value = aws_iam_policy.ssm_environment_specific_access.arn
+  value = var.default_host_policy != null && var.default_host_policy != "" ? aws_iam_policy.ssm_environment_specific_access[0].arn : null
 }
 
 output "iam_profile_name" {


### PR DESCRIPTION
To use the produced IAM policy in the SSM default IAM configuration role created by the parent module